### PR TITLE
Added Ability to customize Repost text with `removalRepostText` in sub settings

### DIFF
--- a/src/processing_modules/submission_modules/image/existing_submission/removeReposts.js
+++ b/src/processing_modules/submission_modules/image/existing_submission/removeReposts.js
@@ -83,14 +83,15 @@ async function removeAsRepost(reddit, submission, lastSubmission, noOriginalSubm
         return;
     }
     const permalink = 'https://www.reddit.com' + await lastSubmission.permalink;
-    let removalReason = outdent`Good post but unfortunately it has been removed because it has been posted recently by another user:
+    const removalRepostText = subSettings.removalRepostText ? subSettings.removalRepostText : "`Good post but unfortunately it has been removed because it has been posted recently by another user:";
+    let removalReason = outdent`${removalRepostText}
 
         * [Submission link](${permalink})
         * [Direct image link](${await lastSubmission.url})`;
     if (noOriginalSubmission) {
         removalReason += outdent` 
 
-        That submission was also removed by a moderator as a repost, so it will have been posted by another user recently.`;
+        That submission was also removed by a moderator as a repost, so it has been posted by another user recently.`;
     } else if (warnAboutDeletedReposts) {
         removalReason += outdent`
         

--- a/src/processing_modules/submission_modules/image/existing_submission/removeReposts.js
+++ b/src/processing_modules/submission_modules/image/existing_submission/removeReposts.js
@@ -91,7 +91,7 @@ async function removeAsRepost(reddit, submission, lastSubmission, noOriginalSubm
     if (noOriginalSubmission) {
         removalReason += outdent` 
 
-        That submission was also removed by a moderator as a repost, so it has been posted by another user recently.`;
+        That submission was also removed by a moderator as a repost, so it will have been posted by another user recently.`;
     } else if (warnAboutDeletedReposts) {
         removalReason += outdent`
         


### PR DESCRIPTION
To customize the text when a repost detected I added the ability to read from the sub settings "removalRepostText", if it exists it will be used. Otherwise the preexisting one will be used.

Note: I was not able to test my line changes on my local build. The bot built and tested on my test subreddits, but It wasn't able to download images for whatever reason on my machine and could test the repost functionality (and was taking down every post as dead image). Also I'm also not a JS dev, so please make sure everything is in order.

~Additionally I changed 1 message that didn't seem to make sense to me to what I think you mean't to say.~