### PR TITLE
Added "approveIfRepostDeleted" argument, to allow disabling of bot approving posts if a repost was previosly deleted.

### DIFF
--- a/src/image_utils.js
+++ b/src/image_utils.js
@@ -75,8 +75,6 @@ export async function getImageUrl(submissionUrl) {
     // http://imgur.com/gallery/HFoOCeg gallery, single image
     // https://imgur.com/gallery/5l71D gallery, multiple images (album)
 
-    // if album data[0] && data[0].link
-
     const isImgur = imageUrl.includes('imgur.com');
     if (isImgur) {
         let imgurHash = imageUrl.split('/')[imageUrl.split('/').length-1];  // http://imgur.com/S1dZBPm.weird?horrible=true

--- a/src/processing_modules/submission_modules/image/existing_submission/removeReposts.js
+++ b/src/processing_modules/submission_modules/image/existing_submission/removeReposts.js
@@ -28,7 +28,9 @@ async function removeReposts(reddit, modComment, submission, lastSubmission, exi
         log.info(`[${subredditName}]`, 'Found matching hash for submission', await printSubmission(submission), ', but approving as the last submission was deleted: http://redd.it/' + existingMagicSubmission.reddit_id);
         existingMagicSubmission.approve = true;
         existingMagicSubmission.reddit_id = await submission.id;
-        submission.approve();
+        if (processorSettings.approveIfRepostDeleted === true) {
+            submission.approve();
+        }
         return false;
     }
 

--- a/src/processing_modules/submission_modules/image/existing_submission/removeReposts.js
+++ b/src/processing_modules/submission_modules/image/existing_submission/removeReposts.js
@@ -48,7 +48,7 @@ async function removeReposts(reddit, modComment, submission, lastSubmission, exi
 
     const lastSubmissionRemoved = await lastSubmission.removed;
     if (!lastSubmissionRemoved || lastIsRemovedAsRepost) {
-        log.info(`[${subredditName}]`, 'Found matching hash for submission ', await printSubmission(submission), ', matched,', existingMagicSubmission.reddit_id,' re-approving as it is over the repost limit.');
+        log.info(`[${subredditName}]`, 'Found matching hash for submission ', await printSubmission(submission), ', matched,', existingMagicSubmission.reddit_id,' - valid as over the repost limit.');
 
         if (processorSettings.approveIfOverRepostDays === true) {
             submission.approve();


### PR DESCRIPTION
(Note this pulls up some commits from master to since develops behind)

I was noticing that the bot was still approving posts which we don't want it to, so here is another config option.